### PR TITLE
Use macos-14 image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
 name: Build
 on:
   push:
-    branches:
-      - main
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: Build
 on:
   push:
+    branches:
+      - main
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     name: Build
+    # CPP-6873: This example is currently not compatible with macos-15
     runs-on: macos-14
     env:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: macos-latest
+    runs-on: macos-14
     env:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
     steps:


### PR DESCRIPTION
After actions/runner-images#12520, `macos-latest` was switched to `macos-15`. However, this example is currently not compatible with MacOS 15 / XCode 16 (in particular, the script `xcov-to-generic.sh`).

This PR uses `macos-14` as the image for the time being. The plan is to follow up on this problem in [CPP-6873](https://sonarsource.atlassian.net/browse/CPP-6873) and restore compatibility with macos-latest.